### PR TITLE
Set a random root password to enable SSH authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM alpine
 MAINTAINER Anil Madhavapeddy <anil@recoil.org>
 RUN apk update && apk add openssh socat
 RUN mkdir /root/.ssh && \
-    chmod 700 /root/.ssh
+    chmod 700 /root/.ssh && \
+    echo "root:$(dd if=/dev/urandom bs=3 count=16 | tr -d '\n')" | chpasswd
 COPY ssh-forward-agent.sh /root/ssh-forward-agent.sh
 COPY docker-entrypoint.sh /
 EXPOSE 22


### PR DESCRIPTION
In recent Alpine versions, the root password is locked and therefore the
SSH daemon does not allow root to log in. To fix this, we set the root
password to a random value.